### PR TITLE
fix: file deletion in dataNodes; file reader, binary file reader and …

### DIFF
--- a/front-end/source/kernel/datanodes/plugins/plugin-generic-binary-file.js
+++ b/front-end/source/kernel/datanodes/plugins/plugin-generic-binary-file.js
@@ -26,7 +26,7 @@
         description: 'Browse to select file.',
         // **type "boolean"** : Will display a checkbox indicating a true/false setting.
         type: 'browseBinary',
-        required: true, //ABK
+        required: false, //ABK
       },
     ],
     expose_as_files: [
@@ -99,7 +99,10 @@
     };
 
     self.setValue = function (path, value) {
-      if (checkValue(value)) {
+      if (_.isEmpty(value)) {
+        currentSettings.content = {};
+        currentSettings.data_path = '';
+      } else if (checkValue(value)) {
         currentSettings.content = { ...value };
         currentSettings.data_path = value?.name;
       }

--- a/front-end/source/kernel/datanodes/plugins/plugin-generic-text-file.js
+++ b/front-end/source/kernel/datanodes/plugins/plugin-generic-text-file.js
@@ -27,7 +27,7 @@
         // **type "boolean"** : Will display a checkbox indicating a true/false setting.
         type: 'browseText',
         accept: 'text/plain',
-        required: true, //ABK
+        required: false, //ABK
       },
     ],
     expose_as_files: [
@@ -100,7 +100,10 @@
     };
 
     self.setValue = function (path, value) {
-      if (checkValue(value)) {
+      if (_.isEmpty(value)) {
+        currentSettings.content = {};
+        currentSettings.data_path = '';
+      } else if (checkValue(value)) {
         currentSettings.content = { ...value };
         currentSettings.data_path = value?.name;
       }

--- a/front-end/source/kernel/datanodes/plugins/plugin-unzip-file.js
+++ b/front-end/source/kernel/datanodes/plugins/plugin-unzip-file.js
@@ -26,7 +26,7 @@
         description: 'Browse to select zipped file.',
         type: 'browseBinary',
         accept: 'application/x-zip-compressed',
-        required: true,
+        required: false,
       },
     ],
     expose_as_files: [
@@ -107,7 +107,11 @@
     };
 
     self.setValue = function (path, value) {
-      if (value?.content && value?.isBinary) {
+      if (_.isEmpty(value)) {
+        currentSettings.content = {};
+        currentSettings.data_path = '';
+        fileStruct = undefined;
+      } else if (value?.content && value?.isBinary) {
         currentSettings.content = { ...value };
         currentSettings.data_path = value?.name;
         fileStruct = undefined;


### PR DESCRIPTION
Disable the required file and allow content deletion for the following dataNodes :

- Generic text file reader
- Generic binary file reader
- Unzip file